### PR TITLE
Remove the default value of aqa-systemtestsRepo #105

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,6 @@ inputs:
   aqa-systemtestsRepo:
     description: 'Personal aqa-systemtests Repo. For example, octocat/aqa-systemtests:test'
     required: false
-    default: 'aqa-systemtest:master'
   openj9_repo:
     description: 'openj9 Repo'
     required: false

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -60,7 +60,9 @@ export async function runaqaTest(
   )
 
   if (buildList.includes('system')) {
+    if (aqa-systemtestsRepo && aqa-systemtestsRepo.length !== 0) {
     getAqaSystemTestsRepo(aqasystemtestsRepo);
+    }
     dependents = await tc.downloadTool(
       'https://ci.adoptopenjdk.net/view/all/job/systemtest.getDependency/lastSuccessfulBuild/artifact/*zip*/dependents.zip'
     )
@@ -232,10 +234,7 @@ async function getAqaTestsRepo(aqatestsRepo: string): Promise<void> {
 }
 
 function getAqaSystemTestsRepo(aqasystemtestsRepo: string) {
-  let repoBranch = ['adoptium/aqa-systemtests', 'master']
-  if (aqasystemtestsRepo.length !== 0) {
-    repoBranch = parseRepoBranch(aqasystemtestsRepo)
-  }
+  const repoBranch = parseRepoBranch(aqasystemtestsRepo)
   process.env.ADOPTOPENJDK_SYSTEMTEST_REPO = repoBranch[0];
   process.env.ADOPTOPENJDK_SYSTEMTEST_BRANCH = repoBranch[1];
 }


### PR DESCRIPTION
Fixes #105

This line: [https://github.com/adoptium/run-aqa/blob/master/action.yml#L26](https://github.com/adoptium/run-aqa/blob/master/action.yml#L26)  is deleted as it is not necessary to reset the default value of aqa-systemtestsRepo.

The function call is moved inside the if block: [https://github.com/adoptium/run-aqa/blob/master/src/runaqa.ts#L63](https://github.com/adoptium/run-aqa/blob/master/src/runaqa.ts#L63)




I have made the changes according to what I understood from the given instructions. I really want to work on this project so if I have done some errors then please let me know. Any help or suggestion for what I should work on would be really appreciable.

Thanks for letting me work on this. :) 

