### PR TITLE
Enhancements to parseRepoBranch()

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3593,7 +3593,14 @@ function runGetSh(tkgRepo, openj9Repo, vendorTestParams) {
 }
 function parseRepoBranch(repoBranch) {
     const tempRepo = repoBranch.replace(/\s/g, '');
-    return tempRepo.split(':');
+    var slashIndexCheck = tempRepo.indexOf( "/" );
+    var colonIndexCheck = tempRepo.indexOf( ":" );
+    if(slashIndexCheck>0 && colonIndexCheck>0 && slashIndexCheck<colonIndexCheck) {
+      return tempRepo.split(':');
+    }
+    else{
+      return "Error in string parameter format. Required form: 'octocat/projectnames:branch' ".split('#');
+    }
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3599,7 +3599,7 @@ function parseRepoBranch(repoBranch) {
       return tempRepo.split(':');
     }
     else{
-      return "Error in string parameter format. Required form: 'octocat/projectnames:branch' ".split('#');
+      return "Error in string parameter format. Required form: 'octocat/projectnames:branch' ";
     }
 }
 

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -269,6 +269,6 @@ function parseRepoBranch(repoBranch: string): string[] {
   if(slashIndexCheck>0 && colonIndexCheck>0 && slashIndexCheck<colonIndexCheck) {
     return tempRepo.split(':')
   } else  {
-    return "Error in string parameter format. Required form: 'octocat/projectnames:branch' ".split('#')
+    return "Error in string parameter format. Required form: 'octocat/projectnames:branch' "
   }
 }

--- a/src/runaqa.ts
+++ b/src/runaqa.ts
@@ -264,5 +264,11 @@ async function runGetSh(
 
 function parseRepoBranch(repoBranch: string): string[] {
   const tempRepo = repoBranch.replace(/\s/g, '')
-  return tempRepo.split(':')
+  var slashIndexCheck = tempRepo.indexOf( "/" )
+  var colonIndexCheck = tempRepo.indexOf( ":" )
+  if(slashIndexCheck>0 && colonIndexCheck>0 && slashIndexCheck<colonIndexCheck) {
+    return tempRepo.split(':')
+  } else  {
+    return "Error in string parameter format. Required form: 'octocat/projectnames:branch' ".split('#')
+  }
 }


### PR DESCRIPTION
## What GitHub issue does this PR apply to?

Resolves #106  

## What changed and why?

Used indexOf() method to find indexes of "/ " and ":" in the string parameter passed in parseRepoBranch() function.  If both the indexes for "/ " and ":" are greater than 0 and index of "/ " is greater than index of ":", all is good and no error message is returned.