### PR TITLE
Removed nightly openj9 testing

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2016]
         version: [8, 11, 17]
-        impl: [hotspot, openj9]
+        impl: [hotspot]
         buildlist: [openjdk, system, functional]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Removed nightly openj9 testing while we do not have fresh nightly/EA builds
Fixes: #119

Signed-off-by: Abhijeet Jejurkar <abhijeet.jejurkar2@gmail.com>