### PR TITLE
Migrate sanity.yml workflow to setup-java action

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,7 +1,7 @@
-name: "nightly sanity test"
+name: "weekly sanity test"
 on:
   schedule:
-    - cron:  '30 20 * * 1-5'
+    - cron:  '30 20 * * 1'
 
 jobs:
   sanity:
@@ -11,16 +11,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         version: [8, 11, 17]
-        impl: [hotspot]
+        distribution: [temurin]
         buildlist: [openjdk, system, functional]
     steps:
     - uses: actions/checkout@v3
-    - uses: AdoptOpenJDK/install-jdk@v1
+    - uses: actions/setup-java@v3
       with:
-        version: ${{ matrix.version }}
-        targets: JDK_${{ matrix.version }}
-        impl: ${{ matrix.impl }}
-        source: 'nightly'
+        java-version: ${{ matrix.version }}
+        distribution: ${{ matrix.impl }}
     - name: AQA
       uses: ./
       with: 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         version: [8, 11, 17]
-        distribution: [temurin]
+        impl: [temurin]
         buildlist: [openjdk, system, functional]
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The AdoptOpenJDK/install-jdk has not been updated in a while but setup-java  is so it probably makes sense to migrate to it. Also see #122 for more details.